### PR TITLE
derive Deserialize removed from all structs which contains refs

### DIFF
--- a/soa-derive-internal/src/refs.rs
+++ b/soa-derive-internal/src/refs.rs
@@ -4,7 +4,7 @@ use structs::Struct;
 pub fn derive(input: &Struct) -> Tokens {
     let name = &input.name;
     let visibility = &input.visibility;
-    let other_derive = &input.derive_no_clone();
+    let other_derive = &input.derive_with_exceptions();
     let vec_name = &input.vec_name();
     let ref_name = &input.ref_name();
     let ref_mut_name = &input.ref_mut_name();

--- a/soa-derive-internal/src/slice.rs
+++ b/soa-derive-internal/src/slice.rs
@@ -2,7 +2,7 @@ use quote::{Tokens, Ident};
 use structs::Struct;
 
 pub fn derive_slice(input: &Struct) -> Tokens {
-    let other_derive = &input.derive_no_clone();
+    let other_derive = &input.derive_with_exceptions();
     let visibility = &input.visibility;
     let slice_name = &input.slice_name();
     let vec_name = &input.vec_name();
@@ -187,7 +187,7 @@ pub fn derive_slice(input: &Struct) -> Tokens {
 
 
 pub fn derive_slice_mut(input: &Struct) -> Tokens {
-    let other_derive = &input.derive_no_clone();
+    let other_derive = &input.derive_with_exceptions();
     let visibility = &input.visibility;
     let slice_name = &input.slice_name();
     let slice_mut_name = &input.slice_mut_name();

--- a/soa-derive-internal/src/structs.rs
+++ b/soa-derive-internal/src/structs.rs
@@ -58,7 +58,7 @@ impl Struct {
         return ident.into();
     }
 
-    pub fn derive_no_clone(&self) -> quote::Ident {
+    pub fn derive_with_exceptions(&self) -> quote::Ident {
         if self.derives.is_empty() {
             return "".into();
         }
@@ -66,6 +66,7 @@ impl Struct {
         ident += &self.derives.iter()
                               .cloned()
                               .filter(|trai| trai != "Clone")
+                              .filter(|trai| trai != "Deserialize")
                               .collect::<Vec<_>>()
                               .join(", ");
         ident += ")]";


### PR DESCRIPTION
Hello,
It would be good if CheeseVec could be serialized + deserialized.

Now Deserialize derive fails on Slice and Refs during compilation.

*** rebased version of PR

Regards,