### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ for name in &vec.name {
 ```
 
 In order to iterate over multiple fields at the same time, one can use the
-[soa_zip!](macro.soa_zip.html) macro.
+[soa_zip!](https://docs.rs/soa_derive/*/soa_derive/macro.soa_zip.html) macro.
 
 ```rust
 for (name, smell, color) in soa_zip!(vec, [name, mut smell, color]) {


### PR DESCRIPTION
The link to the soa_zip macro is dead, presumably because the readme got converted from the doc comment at some previous time. I changed the think to a link to docs.rs that will always link the latest version.