### PR TITLE
Improve hygien of generated code

### DIFF
--- a/soa-derive-internal/src/slice.rs
+++ b/soa-derive-internal/src/slice.rs
@@ -23,12 +23,12 @@ pub fn derive(input: &Input) -> TokenStream {
     let first_field = &fields_names[0];
 
     let fields_names_hygienic_1 = input.fields.iter()
-        .map(|field| field.ident.as_ref().unwrap())
-        .map(|ident| Ident::new(&format!("___soa_derive_private_1_{}", ident), Span::call_site()))
+        .enumerate()
+        .map(|(i, _)| Ident::new(&format!("___soa_derive_private_1_{}", i), Span::call_site()))
         .collect::<Vec<_>>();
     let fields_names_hygienic_2 = input.fields.iter()
-        .map(|field| field.ident.as_ref().unwrap())
-        .map(|ident| Ident::new(&format!("___soa_derive_private_2_{}", ident), Span::call_site()))
+        .enumerate()
+        .map(|(i, _)| Ident::new(&format!("___soa_derive_private_2_{}", i), Span::call_site()))
         .collect::<Vec<_>>();
 
     let fields_types = &input.fields.iter()
@@ -256,12 +256,12 @@ pub fn derive_mut(input: &Input) -> TokenStream {
     let fields_names_2 = &fields_names;
     let first_field = &fields_names[0];
     let slice_names_1 = &input.fields.iter()
-        .map(|field| field.ident.as_ref().unwrap().to_string())
-        .map(|ident| Ident::new(&format!("{}_slice_1", ident), Span::call_site()))
+        .enumerate()
+        .map(|(i, _)| Ident::new(&format!("___soa_derive_private_slice_1_{}", i), Span::call_site()))
         .collect::<Vec<_>>();
     let slice_names_2 = &input.fields.iter()
-        .map(|field| field.ident.as_ref().unwrap().to_string())
-        .map(|ident| Ident::new(&format!("{}_slice_2", ident), Span::call_site()))
+        .enumerate()
+        .map(|(i, _)| Ident::new(&format!("___soa_derive_private_slice_2_{}", i), Span::call_site()))
         .collect::<Vec<_>>();
 
     let fields_types = &input.fields.iter()

--- a/soa-derive-internal/src/vec.rs
+++ b/soa-derive-internal/src/vec.rs
@@ -22,8 +22,8 @@ pub fn derive(input: &Input) -> TokenStream {
                                    .collect::<Vec<_>>();
 
     let fields_names_hygienic = input.fields.iter()
-        .map(|field| field.ident.as_ref().unwrap())
-        .map(|ident| Ident::new(&format!("___soa_derive_private_{}", ident), Span::call_site()))
+        .enumerate()
+        .map(|(i, _)| Ident::new(&format!("___soa_derive_private_{}", i), Span::call_site()))
         .collect::<Vec<_>>();
 
     let first_field = &fields_names[0];

--- a/tests/extreme.rs
+++ b/tests/extreme.rs
@@ -31,3 +31,17 @@ pub struct VeryBig {
     vz: f64,
     name: String,
 }
+
+// strange names used by variables inside the implementation.
+// This checks for hygiene in code generation
+#[derive(Debug, Clone, PartialEq, StructOfArray)]
+pub struct BadNames {
+    pub index: String,
+    pub at: String,
+    pub other: String,
+    pub len: String,
+    pub size: String,
+    pub cap: String,
+    pub capacity: String,
+    pub buf: String,
+}

--- a/tests/extreme.rs
+++ b/tests/extreme.rs
@@ -45,3 +45,10 @@ pub struct BadNames {
     pub capacity: String,
     pub buf: String,
 }
+
+// Raw identifiers
+#[derive(Debug, Clone, PartialEq, StructOfArray)]
+pub struct RawIdent {
+    pub r#for: String,
+    pub r#in: String,
+}


### PR DESCRIPTION
Previous code would fail if one field was named 'index', because it was creating a variable with the same name, overwriting the function parameter