### PR TITLE
fix: make serde working with SOA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ soa_derive_internal = {path = "soa-derive-internal", version = "0.10"}
 
 [dev-dependencies]
 bencher = "0.1"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
 
 [[bench]]
 name = "soa"

--- a/soa-derive-internal/src/input.rs
+++ b/soa-derive-internal/src/input.rs
@@ -68,6 +68,7 @@ impl Input {
                                        .cloned()
                                        .filter(|name| name != "Clone")
                                        .filter(|name| name != "Deserialize")
+                                       .filter(|name| name != "Serialize")
                                        .collect::<Vec<_>>();
             quote!(
                 #[derive(

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+use soa_derive::StructOfArray;
+
+#[derive(Debug, Clone, PartialEq, StructOfArray)]
+#[soa_derive = "Debug, Clone, PartialEq, Serialize, Deserialize"]
+pub struct Particle {
+    pub name: String,
+    pub mass: f64,
+}
+
+impl Particle {
+    pub fn new(name: String, mass: f64) -> Self {
+        Particle {
+            name: name,
+            mass: mass,
+        }
+    }
+}
+
+#[test]
+fn serde_test() -> Result<(), serde_json::Error> {
+    let mut soa = ParticleVec::new();
+    soa.push(Particle::new(String::from("Na"), 56.0));
+    soa.push(Particle::new(String::from("Cl"), 35.0));
+
+    let json = serde_json::to_string(&soa)?;
+    assert_eq!(json, r#"{"name":["Na","Cl"],"mass":[56.0,35.0]}"#);
+    let soa2: ParticleVec = serde_json::from_str(&json)?;
+    assert_eq!(soa, soa2);
+    Ok(())
+}


### PR DESCRIPTION
Previously, when using `soa_derive = "Serialize, Deserialize"`, serde will produce errors about the generated pointers, references, etc. types.

This PR adds a serde test and a simple fix to this issue.