### PR TITLE
Refactor attributes handling

### DIFF
--- a/soa-derive-internal/src/ptr.rs
+++ b/soa-derive-internal/src/ptr.rs
@@ -6,7 +6,6 @@ use crate::input::Input;
 pub fn derive(input: &Input) -> TokenStream {
     let name = &input.name;
     let visibility = &input.visibility;
-    let other_derive = &input.derive_with_exceptions();
     let attrs = &input.attrs.ptr;
     let mut_attrs = &input.attrs.ptr_mut;
     let vec_name = &input.vec_name();
@@ -43,7 +42,6 @@ pub fn derive(input: &Input) -> TokenStream {
         /// An analog of a pointer to
         #[doc = #doc_url]
         /// with struct of array layout.
-        #other_derive
         #(#[#attrs])*
         #[derive(Copy, Clone)]
         #visibility struct #ptr_name {
@@ -56,7 +54,6 @@ pub fn derive(input: &Input) -> TokenStream {
         /// An analog of a mutable pointer to
         #[doc = #doc_url]
         /// with struct of array layout.
-        #other_derive
         #(#[#mut_attrs])*
         #[derive(Copy, Clone)]
         #visibility struct #ptr_mut_name {

--- a/soa-derive-internal/src/refs.rs
+++ b/soa-derive-internal/src/refs.rs
@@ -6,7 +6,6 @@ use crate::input::Input;
 pub fn derive(input: &Input) -> TokenStream {
     let name = &input.name;
     let visibility = &input.visibility;
-    let other_derive = &input.derive_with_exceptions();
     let attrs = &input.attrs.ref_;
     let mut_attrs = &input.attrs.ref_mut;
     let vec_name = &input.vec_name();
@@ -39,7 +38,6 @@ pub fn derive(input: &Input) -> TokenStream {
         /// A reference to a
         #[doc = #doc_url]
         /// with struct of array layout.
-        #other_derive
         #(#[#attrs])*
         #[derive(Copy, Clone)]
         #visibility struct #ref_name<'a> {
@@ -52,7 +50,6 @@ pub fn derive(input: &Input) -> TokenStream {
         /// A mutable reference to a
         #[doc = #doc_url]
         /// with struct of array layout.
-        #other_derive
         #(#[#mut_attrs])*
         #visibility struct #ref_mut_name<'a> {
             #(

--- a/soa-derive-internal/src/slice.rs
+++ b/soa-derive-internal/src/slice.rs
@@ -6,7 +6,6 @@ use quote::quote;
 use crate::input::Input;
 
 pub fn derive(input: &Input) -> TokenStream {
-    let other_derive = &input.derive_with_exceptions();
     let visibility = &input.visibility;
     let slice_name = &input.slice_name();
     let attrs = &input.attrs.slice;
@@ -48,7 +47,6 @@ pub fn derive(input: &Input) -> TokenStream {
         /// .
         #[allow(dead_code)]
         #[derive(Copy, Clone)]
-        #other_derive
         #(#[#attrs])*
         #visibility struct #slice_name<'a> {
             #(
@@ -216,7 +214,7 @@ pub fn derive(input: &Input) -> TokenStream {
         }
     };
 
-    if input.derives.contains(&Ident::new("Clone", Span::call_site())) {
+    if input.attrs.derive_clone {
         generated.append_all(quote!{
             #[allow(dead_code)]
             impl<'a> #slice_name<'a> {
@@ -236,7 +234,6 @@ pub fn derive(input: &Input) -> TokenStream {
 }
 
 pub fn derive_mut(input: &Input) -> TokenStream {
-    let other_derive = &input.derive_with_exceptions();
     let visibility = &input.visibility;
     let slice_name = &input.slice_name();
     let slice_mut_name = &input.slice_mut_name();
@@ -282,7 +279,6 @@ pub fn derive_mut(input: &Input) -> TokenStream {
         #[doc = #vec_doc_url]
         /// .
         #[allow(dead_code)]
-        #other_derive
         #(#[#attrs])*
         #visibility struct #slice_mut_name<'a> {
             #(
@@ -528,7 +524,7 @@ pub fn derive_mut(input: &Input) -> TokenStream {
         }
     };
 
-    if input.derives.contains(&Ident::new("Clone", Span::call_site())) {
+    if input.attrs.derive_clone {
         generated.append_all(quote!{
             #[allow(dead_code)]
             impl<'a> #slice_mut_name<'a> {

--- a/soa-derive-internal/src/vec.rs
+++ b/soa-derive-internal/src/vec.rs
@@ -8,7 +8,6 @@ use crate::input::Input;
 pub fn derive(input: &Input) -> TokenStream {
     let name = &input.name;
     let vec_name_str = format!("Vec<{}>", name);
-    let other_derive = &input.derive();
     let attrs = &input.attrs.vec;
     let visibility = &input.visibility;
     let vec_name = &input.vec_name();
@@ -42,7 +41,6 @@ pub fn derive(input: &Input) -> TokenStream {
         #[doc = #vec_name_str]
         /// ` with Struct of Array (SoA) layout
         #[allow(dead_code)]
-        #other_derive
         #(#[#attrs])*
         #visibility struct #vec_name {
             #(
@@ -352,7 +350,7 @@ pub fn derive(input: &Input) -> TokenStream {
         }
     };
 
-    if input.derives.contains(&Ident::new("Clone", Span::call_site())) {
+    if input.attrs.derive_clone {
         generated.append_all(quote!{
             #[allow(dead_code)]
             impl #vec_name {


### PR DESCRIPTION
In particular, `#[soa_derive]` and `#[soa_attr]` are stored in the same way, and handling of exceptions for soa_derive should be clearer.

This is a follow-up to #37, ping @CurryPseudo if you have thoughts on this!