### PR TITLE
Change the syntax for soa_derive to be closer to usual `#[derive]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soa_derive"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2018"
 authors = ["Guillaume Fraux <guillaume.fraux@chimie-paristech.fr>"]
 license = "MIT/Apache-2.0"
@@ -19,7 +19,7 @@ members = [
 ]
 
 [dependencies]
-soa_derive_internal = {path = "soa-derive-internal", version = "0.10"}
+soa_derive_internal = {path = "soa-derive-internal", version = "0.11"}
 
 [dev-dependencies]
 bencher = "0.1"

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ You can use `<Cheese as StructOfArray>::Type` instead of the explicitly named ty
 
 Add `#[derive(StructOfArray)]` to each struct you want to derive a struct of
 array version. If you need the helper structs to derive additional traits (such
-as `Debug` or `PartialEq`), you can add an attribute `#[soa_derive = "Debug,
-PartialEq"]` to the struct declaration.
+as `Debug` or `PartialEq`), you can add an attribute `#[soa_derive(Debug,
+PartialEq)]` to the struct declaration.
 
 ```rust
 #[derive(Debug, PartialEq, StructOfArray)]
-#[soa_derive = "Debug, PartialEq"]
+#[soa_derive(Debug, PartialEq)]
 pub struct Cheese {
     pub smell: f64,
     pub color: (f64, f64, f64),
@@ -54,9 +54,9 @@ pub struct Cheese {
 }
 ```
 
-If you want to add attribute to a specific generated struct(such as 
+If you want to add attribute to a specific generated struct(such as
 `#[cfg_attr(test, derive(PartialEq))]` on `CheeseVec`), you can add an
-attribute `#[soa_attr(Vec, cfg_attr(test, derive(PartialEq)))]` to the 
+attribute `#[soa_attr(Vec, cfg_attr(test, derive(PartialEq)))]` to the
 struct declaration.
 
 ```rust
@@ -70,7 +70,7 @@ pub struct Cheese {
 }
 ```
 
-Mappings for first argument of ``soa_attr`` to the generated struct for ``Cheese``: 
+Mappings for first argument of ``soa_attr`` to the generated struct for ``Cheese``:
 * `Vec` => `CheeseVec`
 * `Slice` => `CheeseSlice`
 * `SliceMut` => `CheeseSliceMut`

--- a/benches/soa.rs
+++ b/benches/soa.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_return)]
+
 use soa_derive::StructOfArray;
 
 use bencher::{Bencher, benchmark_group, benchmark_main};

--- a/example/lib.rs
+++ b/example/lib.rs
@@ -42,7 +42,7 @@ extern crate soa_derive;
 
 /// A basic Particle type
 #[derive(Debug, PartialEq, StructOfArray)]
-#[soa_derive = "Debug, PartialEq"]
+#[soa_derive(Debug, PartialEq)]
 pub struct Particle {
     /// Mass of the particle
     pub mass: f64,

--- a/soa-derive-internal/Cargo.toml
+++ b/soa-derive-internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soa_derive_internal"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2018"
 authors = ["Guillaume Fraux <guillaume.fraux@chimie-paristech.fr>"]
 license = "MIT/Apache-2.0"

--- a/soa-derive-internal/src/input.rs
+++ b/soa-derive-internal/src/input.rs
@@ -163,7 +163,11 @@ impl Input {
                             ..
                         }) => {
                             for value in string.value().split(',') {
-                                extra_attrs.add_derive(value.trim());
+                                let value = value.trim();
+                                if value == "Copy" {
+                                    panic!("can not derive Copy for SoA vectors");
+                                }
+                                extra_attrs.add_derive(value);
                             }
                         }
                         _ => panic!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! # #[macro_use] extern crate soa_derive;
 //! # fn main() {
 //! #[derive(Debug, PartialEq, StructOfArray)]
-//! #[soa_derive = "Debug, PartialEq"]
+//! #[soa_derive(Debug, PartialEq)]
 //! pub struct Cheese {
 //!     pub smell: f64,
 //!     pub color: (f64, f64, f64),

--- a/tests/particles/mod.rs
+++ b/tests/particles/mod.rs
@@ -1,7 +1,7 @@
 use soa_derive::StructOfArray;
 
 #[derive(Debug, Clone, PartialEq, StructOfArray)]
-#[soa_derive = "Debug, Clone, PartialEq"]
+#[soa_derive(Debug, Clone, PartialEq)]
 pub struct Particle {
     pub name: String,
     pub mass: f64,

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use soa_derive::StructOfArray;
 
 #[derive(Debug, Clone, PartialEq, StructOfArray)]
-#[soa_derive = "Debug, Clone, PartialEq, Serialize, Deserialize"]
+#[soa_derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Particle {
     pub name: String,
     pub mass: f64,


### PR DESCRIPTION
This is a breaking change and will be released in a new 0.11 version.