### PR TITLE
Add `Vec::replace` and `MutRef::replace`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/tests/replace.rs
+++ b/tests/replace.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::float_cmp)]
+
+mod particles;
+use self::particles::{Particle, ParticleVec};
+
+#[test]
+fn replace_element() {
+    let mut soa = ParticleVec::new();
+    soa.push(Particle::new(String::from("Na"), 22.990));
+    soa.push(Particle::new(String::from("Zn"), 65.380));
+    soa.push(Particle::new(String::from("Cl"), 35.453));
+
+    let particle = soa.replace(1, Particle::new(String::from("Br"), 79.904));
+    assert_eq!(particle.name, "Zn");
+    assert_eq!(particle.mass, 65.380);
+
+    assert_eq!(soa.name[1], "Br");
+    assert_eq!(soa.mass[1], 79.904);
+}
+
+#[test]
+fn replace_mutable_reference() {
+    let mut soa = ParticleVec::new();
+    soa.push(Particle::new(String::from("Na"), 22.990));
+    soa.push(Particle::new(String::from("Zn"), 65.380));
+    soa.push(Particle::new(String::from("Cl"), 35.453));
+
+    let particle = soa.index_mut(1).replace(Particle::new(String::from("Br"), 79.904));
+    assert_eq!(particle.name, "Zn");
+    assert_eq!(particle.mass, 65.380);
+
+    assert_eq!(soa.name[1], "Br");
+    assert_eq!(soa.mass[1], 79.904);
+}


### PR DESCRIPTION
These are similar to `std::mem::replace` in that they replace the value at the given index or reference and then return the old value. If the return value is ignored, then `replace` effectively acts as an assignment. In other words, `foo.replace(index, element)` is the same as `foo[index] = element` and `foo.replace(val)` as `*foo = val`. This always creates a new instance of the struct, which we have to do anyways in case the `Drop` trait is implemented.