### PR TITLE
Always implement Default for Vec

### DIFF
--- a/soa-derive-internal/src/input.rs
+++ b/soa-derive-internal/src/input.rs
@@ -116,8 +116,10 @@ impl Input {
                     match meta.path.get_ident() {
                         Some(ident) => {
                             assert!(ident != "Copy", "can not derive Copy for SoA vectors");
-                            assert!(ident != "Default", "Default is already derived for SoA vectors");
-                            extra_attrs.add_derive(ident);
+                            if ident != "Default" {
+                                // ignore as Default is already derived for SoA vectors, slices and mut slices
+                                extra_attrs.add_derive(ident);
+                            }
                         }
                         None => {
                             panic!(

--- a/soa-derive-internal/src/input.rs
+++ b/soa-derive-internal/src/input.rs
@@ -116,6 +116,7 @@ impl Input {
                     match meta.path.get_ident() {
                         Some(ident) => {
                             assert!(ident != "Copy", "can not derive Copy for SoA vectors");
+                            assert!(ident != "Default", "Default is already derived for SoA vectors");
                             extra_attrs.add_derive(ident);
                         }
                         None => {

--- a/soa-derive-internal/src/slice.rs
+++ b/soa-derive-internal/src/slice.rs
@@ -63,6 +63,7 @@ pub fn derive(input: &Input) -> TokenStream {
         #[allow(dead_code)]
         #[derive(Copy, Clone)]
         #(#[#attrs])*
+        #[derive(Default)]
         #visibility struct #slice_name<'a> {
             #(
                 /// slice of `
@@ -337,6 +338,7 @@ pub fn derive_mut(input: &Input) -> TokenStream {
         /// .
         #[allow(dead_code)]
         #(#[#attrs])*
+        #[derive(Default)]
         #visibility struct #slice_mut_name<'a> {
             #(
                 /// slice of `

--- a/soa-derive-internal/src/vec.rs
+++ b/soa-derive-internal/src/vec.rs
@@ -74,6 +74,7 @@ pub fn derive(input: &Input) -> TokenStream {
         /// ` with Struct of Array (SoA) layout
         #[allow(dead_code)]
         #(#[#attrs])*
+        #[derive(Default)]
         #visibility struct #vec_name {
             #(
                 /// a vector of `

--- a/soa-derive-internal/src/vec.rs
+++ b/soa-derive-internal/src/vec.rs
@@ -40,11 +40,6 @@ pub fn derive(input: &Input) -> TokenStream {
         |_, field_type| quote! { Vec<#field_type> },
     ).collect::<Vec<_>>();
 
-    let vec_new = input.map_fields_nested_or(
-        |_, field_type| quote! { <#field_type as StructOfArray>::Type::new()},
-        |_, _| quote! { Vec::new() },
-    ).collect::<Vec<_>>();
-
     let vec_with_capacity = input.map_fields_nested_or(
         |_, field_type| quote! { <#field_type as StructOfArray>::Type::with_capacity(capacity) },
         |_, _| quote! { Vec::with_capacity(capacity) },
@@ -92,9 +87,7 @@ pub fn derive(input: &Input) -> TokenStream {
             #[doc = #vec_name_str]
             /// ::new()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.new)
             pub fn new() -> #vec_name {
-                #vec_name {
-                    #( #fields_names: #vec_new, )*
-                }
+                Default::default()
             }
 
             /// Similar to [`

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -11,6 +11,11 @@ fn ty() {
 }
 
 #[test]
+fn default() {
+    assert_eq!(ParticleVec::new(), ParticleVec::default());
+}
+
+#[test]
 fn push() {
     let mut particles = ParticleVec::new();
     particles.push(Particle::new(String::from("Na"), 56.0));

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -11,11 +11,6 @@ fn ty() {
 }
 
 #[test]
-fn default() {
-    assert_eq!(ParticleVec::new(), ParticleVec::default());
-}
-
-#[test]
 fn push() {
     let mut particles = ParticleVec::new();
     particles.push(Particle::new(String::from("Na"), 56.0));


### PR DESCRIPTION
I propose to always implement `Default` for `Vec`.

This makes it behave more like [`std::vec::Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html), which [implements `Default` regardless of `T`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-Default-for-Vec%3CT%3E).