### PR TITLE
Implement Extend for Vec

### DIFF
--- a/soa-derive-internal/src/iter.rs
+++ b/soa-derive-internal/src/iter.rs
@@ -25,6 +25,10 @@ pub fn derive(input: &Input) -> TokenStream {
         .map(|field| field.ident.clone().unwrap())
         .collect::<Vec<_>>();
 
+    let fields_types = &input.fields.iter()
+        .map(|field| field.ty.clone())
+        .collect::<Vec<_>>();
+
     let iter_type = input.map_fields_nested_or(
         |_, field_type| quote! { <#field_type as soa_derive::SoAIter<'a>>::Iter },
         |_, field_type| quote! { slice::Iter<'a, #field_type> },
@@ -295,6 +299,16 @@ pub fn derive(input: &Input) -> TokenStream {
                     for item in iter {
                         self.push(item)
                     }
+                }
+            }
+
+            impl<'a> Extend<#ref_name<'a>> for #vec_name
+                // only expose if all fields are Clone
+                // https://github.com/rust-lang/rust/issues/48214#issuecomment-1150463333
+                where #( for<'b> #fields_types: Clone, )*
+            {
+                fn extend<I: IntoIterator<Item = #ref_name<'a>>>(&mut self, iter: I) {
+                    self.extend(iter.into_iter().map(|item| item.to_owned()))
                 }
             }
         });

--- a/soa-derive-internal/src/iter.rs
+++ b/soa-derive-internal/src/iter.rs
@@ -289,6 +289,14 @@ pub fn derive(input: &Input) -> TokenStream {
                     self.as_mut_slice().into_iter()
                 }
             }
+
+            impl Extend<#name> for #vec_name {
+                fn extend<I: IntoIterator<Item = #name>>(&mut self, iter: I) {
+                    for item in iter {
+                        self.push(item)
+                    }
+                }
+            }
         });
     }
 

--- a/soa-derive-internal/src/refs.rs
+++ b/soa-derive-internal/src/refs.rs
@@ -122,7 +122,7 @@ pub fn derive(input: &Input) -> TokenStream {
             /// into an owned value. This is only available if all fields
             /// implement `Clone`.
             pub fn to_owned(&self) -> #name
-                // only expose to_owned is all fields are Clone
+                // only expose to_owned if all fields are Clone
                 // https://github.com/rust-lang/rust/issues/48214#issuecomment-1150463333
                 where #( for<'b> #fields_types: Clone, )*
             {
@@ -138,7 +138,7 @@ pub fn derive(input: &Input) -> TokenStream {
             /// into an owned value. This is only available if all fields
             /// implement `Clone`.
             pub fn to_owned(&self) -> #name
-                // only expose to_owned is all fields are Clone
+                // only expose to_owned if all fields are Clone
                 // https://github.com/rust-lang/rust/issues/48214#issuecomment-1150463333
                 where #( for<'b> #fields_types: Clone, )*
             {

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -69,3 +69,19 @@ fn from_iter() {
 
     assert_eq!(particles, particles_from_iter)
 }
+
+#[test]
+fn extend() {
+    let vec_with_particles = vec![
+        Particle::new(String::from("Na"), 0.0),
+        Particle::new(String::from("Cl"), 0.0),
+        Particle::new(String::from("Zn"), 0.0),
+    ];
+
+    let particles_from_iter: ParticleVec = vec_with_particles.clone().into_iter().collect();
+
+    let mut particles = ParticleVec::new();
+    particles.extend(vec_with_particles);
+
+    assert_eq!(particles, particles_from_iter)
+}


### PR DESCRIPTION
I would like to implement `Extend<&'a #name> for #vec_name` as well (just like [`std::vec::Vec<T>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-Extend%3C%26T%3E-for-Vec%3CT,+A%3E)), but I would have to make sure `#name` is `Copy` (`where #name: Copy` does not help).

This is not the most performant implementation either, but it works.

Fix #51.