### PR TITLE
Make 'apply_permutation' function public

### DIFF
--- a/soa-derive-internal/src/slice.rs
+++ b/soa-derive-internal/src/slice.rs
@@ -601,7 +601,9 @@ pub fn derive_mut(input: &Input) -> TokenStream {
             }
 
             #[doc(hidden)]
-            pub fn apply_permutation(&mut self, permutation: &mut soa_derive::Permutation) {
+            /// this is `pub` due to the issue in https://github.com/lumol-org/soa-derive/pull/65
+            /// but should not be used directly
+            pub fn __private_apply_permutation(&mut self, permutation: &mut soa_derive::Permutation) {
                 #( #apply_permutation; )*
             }
 

--- a/soa-derive-internal/src/slice.rs
+++ b/soa-derive-internal/src/slice.rs
@@ -601,7 +601,7 @@ pub fn derive_mut(input: &Input) -> TokenStream {
             }
 
             #[doc(hidden)]
-            fn apply_permutation(&mut self, permutation: &mut soa_derive::Permutation) {
+            pub fn apply_permutation(&mut self, permutation: &mut soa_derive::Permutation) {
                 #( #apply_permutation; )*
             }
 


### PR DESCRIPTION
As of now, If I have struct A, which is a field of struct B using `#[nested_soa]` in a different file, it will complain that `apply_permutation` is private.