### PR TITLE
Make test ptr::slice_mut compliant with Tree Borrows

### DIFF
--- a/tests/ptr.rs
+++ b/tests/ptr.rs
@@ -86,7 +86,7 @@ fn slice_mut() {
     assert_eq!(slice.mass[0], 42.0);
 
     unsafe {
-        let slice = ParticleSliceMut::from_raw_parts_mut(ptr, 2);
+        let slice = ParticleSliceMut::from_raw_parts_mut(slice.as_mut_ptr(), 2);
 
         for mass in slice.mass {
             *mass = -1.0;


### PR DESCRIPTION
[Tree Borrows](https://www.ralfj.de/blog/2023/06/02/tree-borrows.html) is a new aliasing model for Rust, which features more precise tracking of pointer aliasing. The aim is to be more lenient than Stacked Borrows, while also having less dirty hacks than SB had.

It turns out that the **test** `ptr::slice_mut` here relied on one such hack.

The problematic code is here:
https://github.com/lumol-org/soa-derive/blob/ad918be58f47ee6d38e9c83411180e756a3220c0/tests/ptr.rs#L77-L93 There, a slice is created, and then a reference to it is obtained using `slice::as_mut_ptr()`, which (internally) creates a new mutable reference. This means that the resulting pointer can not be mixed with accesses to the original slice.

However, the test does so: It first uses the pointer, then the original slice, and then again the pointer. The proper solution is to re-derive the pointer when it's needed again, which is what this PR does.