### PR TITLE
Fix the access of `extend`.

### DIFF
--- a/soa-derive-internal/src/iter.rs
+++ b/soa-derive-internal/src/iter.rs
@@ -293,7 +293,7 @@ pub fn derive(input: &Input) -> TokenStream {
             where #( for<'b> #fields_types: Clone, )*
         {
             fn extend<I: IntoIterator<Item = #ref_name<'a>>>(&mut self, iter: I) {
-                self.extend(iter.into_iter().map(|item| item.to_owned()))
+                <Self as Extend<#name>>::extend(self, iter.into_iter().map(|item| item.to_owned()))
             }
         }
 

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::float_cmp)]
 
 mod particles;
-use self::particles::{Particle, ParticleVec};
+use self::particles::*;
 
 #[test]
 fn iter() {
@@ -81,7 +81,15 @@ fn extend() {
     let particles_from_iter: ParticleVec = vec_with_particles.clone().into_iter().collect();
 
     let mut particles = ParticleVec::new();
-    particles.extend(vec_with_particles);
+    Extend::<Particle>::extend(&mut particles, vec_with_particles);
 
-    assert_eq!(particles, particles_from_iter)
+    assert_eq!(particles, particles_from_iter);
+
+    let mut particles = ParticleVec::new();
+    Extend::<ParticleRef>::extend(&mut particles, particles_from_iter.iter());
+    assert_eq!(particles, particles_from_iter);
+
+    let mut particles = ParticleVec::new();
+    particles.extend(&particles_from_iter);
+    assert_eq!(particles, particles_from_iter);
 }

--- a/tests/particles/mod.rs
+++ b/tests/particles/mod.rs
@@ -18,6 +18,12 @@ impl Particle {
     }
 }
 
+impl ParticleVec {
+    pub fn extend(&mut self, other: &ParticleVec) {
+        self.name.extend_from_slice(&other.name);
+        self.mass.extend_from_slice(&other.mass);
+    }
+}
 
 mod impls {
     use std::cmp::Ordering;


### PR DESCRIPTION
 There will be a compile error if the user implements `extend` for `XxxxVec`. So I fixed the way to access `Extend::<#name>::extend`.