### PR TITLE
Optimize `FromIterator` and `retain_mut` + Fixes out-of-bound UB access.

### DIFF
--- a/benches/soa.rs
+++ b/benches/soa.rs
@@ -168,6 +168,17 @@ fn soa_big_do_work_100k(bencher: &mut Bencher) {
     })
 }
 
+fn soa_big_do_work_simple_100k(bencher: &mut Bencher) {
+    let vec = Big::soa_vec(100_000);
+    bencher.iter(||{
+        let mut s = 0.0;
+        for elem in vec.iter() {
+            s += elem.position.0 + elem.velocity.0;
+        }
+        s
+    })
+}
+
 
 benchmark_group!(aos,
     aos_small_push, aos_big_push, aos_small_do_work_100k, aos_big_do_work_10k,
@@ -175,6 +186,6 @@ benchmark_group!(aos,
 );
 benchmark_group!(soa,
     soa_small_push, soa_big_push, soa_small_do_work_100k, soa_big_do_work_10k,
-    soa_big_do_work_100k
+    soa_big_do_work_100k, soa_big_do_work_simple_100k,
 );
 benchmark_main!(soa, aos);

--- a/soa-derive-internal/src/iter.rs
+++ b/soa-derive-internal/src/iter.rs
@@ -235,11 +235,9 @@ pub fn derive(input: &Input) -> TokenStream {
 
         impl std::iter::FromIterator<#name> for #vec_name {
             fn from_iter<T: IntoIterator<Item=#name>>(iter: T) -> Self {
-                let mut iterator = iter.into_iter();
-                let mut result = #vec_name::new();
-                if let Some(len) = iterator.size_hint().1 {
-                    result.reserve(len);
-                }
+                let iterator = iter.into_iter();
+                let capacity = iterator.size_hint().1.unwrap_or(0);
+                let mut result = #vec_name::with_capacity(capacity);
                 iterator.for_each(|element| result.push(element));
                 result
             }

--- a/soa-derive-internal/src/iter.rs
+++ b/soa-derive-internal/src/iter.rs
@@ -235,10 +235,12 @@ pub fn derive(input: &Input) -> TokenStream {
 
         impl std::iter::FromIterator<#name> for #vec_name {
             fn from_iter<T: IntoIterator<Item=#name>>(iter: T) -> Self {
+                let mut iterator = iter.into_iter();
                 let mut result = #vec_name::new();
-                for element in iter {
-                    result.push(element);
+                if let Some(len) = iterator.size_hint().1 {
+                    result.reserve(len);
                 }
+                iterator.for_each(|element| result.push(element));
                 result
             }
         }

--- a/soa-derive-internal/src/vec.rs
+++ b/soa-derive-internal/src/vec.rs
@@ -196,7 +196,7 @@ pub fn derive(input: &Input) -> TokenStream {
             /// ::insert()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.insert).
             #[allow(clippy::forget_non_drop)]
             pub fn insert(&mut self, index: usize, element: #name) {
-                if index > self.len() {
+                if index >= self.len() {
                     panic!("index out of bounds: the len is {} but the index is {}", self.len(), index);
                 }
 
@@ -213,7 +213,7 @@ pub fn derive(input: &Input) -> TokenStream {
             /// Similar to [`std::mem::replace()`](https://doc.rust-lang.org/std/mem/fn.replace.html).
             #[allow(clippy::forget_non_drop)]
             pub fn replace(&mut self, index: usize, element: #name) -> #name {
-                if index > self.len() {
+                if index >= self.len() {
                     panic!("index out of bounds: the len is {} but the index is {}", self.len(), index);
                 }
 


### PR DESCRIPTION
Hi,
I optimized `FromIterator` and `retain_mut` with this PR.
I already have a PR for rust standard library to use this `retain_mut` algorithm instead. it is faster for when delete actually happens as it doesn't calculate `current-deleted_count` each time, and also I used `slice.len();` instead of `self.len();` which helps LLVM to eliminate bound checking better.

I also added a benchmark for using simple ref, LLVM is smart enough to optimize simple ref iterations to be as fast as `zip` method.
Maybe worth adding that to README too as it helps people to more easily adapt this library.